### PR TITLE
Rename package to enable Fastly CLI v4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,27 +108,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "compute-starter-kit-rust"
-version = "0.2.0"
-dependencies = [
- "anyhow",
- "base64",
- "fastly",
- "hex",
- "jwt-simple",
- "log",
- "log-fastly",
- "once_cell",
- "rand",
- "regex",
- "serde",
- "serde_json",
- "time",
- "toml",
- "urlencoding",
-]
-
-[[package]]
 name = "const-oid"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -279,6 +258,27 @@ dependencies = [
  "thiserror",
  "time",
  "url",
+]
+
+[[package]]
+name = "fastly-compute-project"
+version = "0.2.0"
+dependencies = [
+ "anyhow",
+ "base64",
+ "fastly",
+ "hex",
+ "jwt-simple",
+ "log",
+ "log-fastly",
+ "once_cell",
+ "rand",
+ "regex",
+ "serde",
+ "serde_json",
+ "time",
+ "toml",
+ "urlencoding",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "compute-starter-kit-rust"
+name = "fastly-compute-project"
 version = "0.2.0"
 authors = ["oss@fastly"]
 edition = "2018"


### PR DESCRIPTION
The next release of the Fastly CLI will require all Rust starter kits to use the same package name.