### PR TITLE
remove build scripts from fastly.toml

### DIFF
--- a/fastly.toml
+++ b/fastly.toml
@@ -1,12 +1,8 @@
-# This file describes a Fastly Compute@Edge package. To learn more visit:
-# https://developer.fastly.com/reference/fastly-toml/
-
 authors = ["<oss@fastly.com>"]
 description = "Starter kit for Google Bigquery Connector."
 language = "rust"
 manifest_version = 2
 name = "Connect to Google Bigquery for Rust"
-service_id = ""
 
 [local_server]
 
@@ -17,6 +13,3 @@ service_id = ""
 
     [local_server.backends.idp]
       url = "https://oauth2.googleapis.com/"
-
-[scripts]
-  build = "cargo build --bin fastly-compute-project --release --target wasm32-wasi --color always"


### PR DESCRIPTION
Context: https://github.com/fastly/compute-starter-kit-rust-static-content/pull/22#discussion_r1088904863