### PR TITLE
Pin jwt-simple to 0.12.16 or later

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ serde = { version = "^1.0.189", features = ["derive"] }
 serde_json = "^1.0.107"
 base64 = "^0.22.1"
 toml = "^1.0.1"
-jwt-simple = "^0.12.12"
+jwt-simple = "^0.12.16"
 anyhow = "^1.0"
 once_cell = "^1.18.0"
 hex = "^0.4.3"


### PR DESCRIPTION
This version (and the version of 'superboring' which it depends on) are required for compatibility with the latest versions of the ml-dsa crate.